### PR TITLE
Fix typo on page about wolfram

### DIFF
--- a/catalog/wolfram.html
+++ b/catalog/wolfram.html
@@ -22,7 +22,7 @@
       <section>
         <h1 id="Wolfram-Language">Wolfram Language</h1>
         <em>Reviewed July 17, 2019</em>
-        <p>Wolfram Language, a <a href="http://community.wolfram.com/groups/-/m/t/1096129">confusing rebranding of Mathematia</a>, is a programming language and notebook-based browser environment. It has 5,000 functions and data sources built into the language -- no imports required. It has broad applications in engineering, sciences, mathematics, finance and education.</p>
+        <p>Wolfram Language, a <a href="http://community.wolfram.com/groups/-/m/t/1096129">confusing rebranding of Mathematica</a>, is a programming language and notebook-based browser environment. It has 5,000 functions and data sources built into the language -- no imports required. It has broad applications in engineering, sciences, mathematics, finance and education.</p>
       </section>
 
       <section>


### PR DESCRIPTION
Hyperlinks text was "confusing rebranding of Mathematia", changed it to "confusing rebranding of Mathematica".

Link to page [https://futureofcoding.org/catalog/wolfram.html](https://futureofcoding.org/catalog/wolfram.html)